### PR TITLE
rename VV

### DIFF
--- a/dist/api/json/metadata-nomenclature.json
+++ b/dist/api/json/metadata-nomenclature.json
@@ -133,7 +133,7 @@
       "info": "<p> Pergament – 320 Blätter – Format: 39 x 26,7 cm (Schriftraum 33–33,5 x 17–19,5 cm), zwei Spalten zu 48–55 (meist 49 oder 50) Zeilen (Textura), Verse abgesetzt – datiert auf 1331–1336 – niederalemannisch\/elsässisch – Sammelhandschrift, Inhalt: Wolframs ›Parzival‹ (Bücher I–XIV), Minneliedstrophen, ›Der Neue Parzival‹, Wolframs ›Parzival‹ (Bücher XV\/XVI), Epilog von Philipp Colin, Minneliedstrophen – Abschnittsgliederung durch Fleuronnée-Initialen an den Abschnittsanfängen, teilweise mit Masken geschmückt; zahlreiche Überschriften und redaktionelle Notizen, um die heterogenen Teile zu einem Ganzen zusammenzufügen – Fassungszugehörigkeit: *T (1.1–733.30) und *m (734.1–827.30) – vgl. zur Hs. auch die Angaben im <a href=\"http:\/\/www.handschriftencensus.de\/5020\" target=\"_blank\">Handschriftencensus<\/a>.<\/p>"
     },
     {
-      "sigil": "VV",
+      "sigil": "V'",
       "aka": "",
       "part": [ { "loc":"Rom, Biblioteca Casanatense", "id":"Mss. 1409" } ],
       "handle": "vv",


### PR DESCRIPTION
The name of the sigil with the handle _vv_ was wrong.